### PR TITLE
Provide sample httpsink receiver server

### DIFF
--- a/sinks/samplehttpsink/Dockerfile
+++ b/sinks/samplehttpsink/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.9-alpine
+
+RUN apk add --no-cache git
+COPY server.go .
+RUN go get -v -d ./...
+
+RUN go build -o httpsink
+ENTRYPOINT ./httpsink

--- a/sinks/samplehttpsink/server.go
+++ b/sinks/samplehttpsink/server.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/crewjam/rfc5424"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("request method=%s from=%s", r.Method, r.RemoteAddr)
+	if r.Body == nil {
+		return
+	}
+	defer r.Body.Close()
+	m := new(rfc5424.Message)
+	for {
+		_, err := m.ReadFrom(r.Body)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatalf("Parsing rfc5424 message failed: %+v", err)
+		}
+		log.Printf("%s", m.Message)
+	}
+}
+
+func main() {
+	log.Println("starting httpsink server")
+	http.HandleFunc("/", handler)
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/sinks/samplehttpsink/server.go
+++ b/sinks/samplehttpsink/server.go
@@ -14,7 +14,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
+
 	m := new(rfc5424.Message)
+	discardBuf := make([]byte, 1)
 	for {
 		_, err := m.ReadFrom(r.Body)
 		if err == io.EOF {
@@ -23,6 +25,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			log.Fatalf("Parsing rfc5424 message failed: %+v", err)
 		}
 		log.Printf("%s", m.Message)
+
+		// read the extraneous \n at the end of the message and discard
+		_, _ = io.ReadFull(r.Body, discardBuf)
 	}
 }
 


### PR DESCRIPTION
A simple webserver just echoes the received rfc5424 message to stdout. Comes
with its own Dockerfile. Currently not vendoring the rfc5424 library for
simplicity. This should help repro the bug report at #33.

Fixes #32.