### PR TITLE
Don't forward syncInterval update events

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -118,6 +118,12 @@ func (er *EventRouter) addEvent(obj interface{}) {
 func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 	eOld := objOld.(*v1.Event)
 	eNew := objNew.(*v1.Event)
+	if eOld.ResourceVersion == eNew.ResourceVersion {
+		// This is just a syncInterval update and the event should have already
+		// been processed, so drop it.
+		return
+	}
+
 	prometheusEvent(eNew)
 	er.eSink.UpdateEvents(eNew, eOld)
 }


### PR DESCRIPTION
## Description

This modifies the update function to not forward events if the `ResourceVersion` of the old event (the event itself, not the associated object) is the same as the new one. [See here for more info](https://github.com/kubernetes/sample-controller/blob/master/controller.go#L139-L143), also [here under item 9](https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md).

I can't think of a case where we wouldn't want to just drop duplicate events, but let me know if there's a reason for continuing to forward them!

## Testing

Set the resync period to a minute and see that events are no longer forwarded at every resync when no actual events are occurring (as compared to `kubectl get events -w`).