### PR TITLE
feat: param for kafka sasl auth

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,10 @@
 {
 "kubeconfig": "/var/run/kubernetes/admin.kubeconfig",
 "sink": "glog",
+"kafkaBrokers": "kafka:9092",
+"kafkaTopic": "topic",
+"kafkaSaslUser": "user",
+"kafkaSaslPwd": "password"
 "httpSinkUrl": "http://localhost:8080",
 "httpSinkBufferSize": 1500,
 "httpSinkDiscardMessages": true,

--- a/sinks/interfaces.go
+++ b/sinks/interfaces.go
@@ -63,13 +63,17 @@ func ManufactureSink() (e EventSinkInterface) {
 		viper.SetDefault("kafkaTopic", "eventrouter")
 		viper.SetDefault("kafkaAsync", true)
 		viper.SetDefault("kafkaRetryMax", 5)
+		viper.SetDefault("kafkaSaslUser", "")
+		viper.SetDefault("kafkaSaslPwd", "")
 
 		brokers := viper.GetStringSlice("kafkaBrokers")
 		topic := viper.GetString("kafkaTopic")
 		async := viper.GetBool("kakfkaAsync")
 		retryMax := viper.GetInt("kafkaRetryMax")
+		saslUser := viper.GetString("kafkaSaslUser")
+		saslPwd := viper.GetString("kafkaSaslPwd")
 
-		e, err := NewKafkaSink(brokers, topic, async, retryMax)
+		e, err := NewKafkaSink(brokers, topic, async, retryMax, saslUser, saslPwd)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/sinks/kafkasink.go
+++ b/sinks/kafkasink.go
@@ -30,9 +30,9 @@ type KafkaSink struct {
 }
 
 // NewKafkaSinkSink will create a new KafkaSink with default options, returned as an EventSinkInterface
-func NewKafkaSink(brokers []string, topic string, async bool, retryMax int) (EventSinkInterface, error) {
+func NewKafkaSink(brokers []string, topic string, async bool, retryMax int, saslUser string, saslPwd string) (EventSinkInterface, error) {
 
-	p, err := sinkFactory(brokers, async, retryMax)
+	p, err := sinkFactory(brokers, async, retryMax, saslUser, saslPwd)
 
 	if err != nil {
 		return nil, err
@@ -44,10 +44,16 @@ func NewKafkaSink(brokers []string, topic string, async bool, retryMax int) (Eve
 	}, err
 }
 
-func sinkFactory(brokers []string, async bool, retryMax int) (interface{}, error) {
+func sinkFactory(brokers []string, async bool, retryMax int, saslUser string, saslPwd string) (interface{}, error) {
 	config := sarama.NewConfig()
 	config.Producer.Retry.Max = retryMax
 	config.Producer.RequiredAcks = sarama.WaitForAll
+
+	if saslUser != "" && saslPwd != "" {
+		config.Net.SASL.Enable = true
+		config.Net.SASL.User = saslUser
+		config.Net.SASL.Password = saslPwd
+	}
 
 	if async {
 		return sarama.NewAsyncProducer(brokers, config)


### PR DESCRIPTION
This pull request adds support for kafka SASL authentication.  Devs can simply add SASL user and password in configuration file to enable SASL authentication in client side rather than hard code in anywhere.

Does it makes any sense for you?