### PR TITLE
add enable_prometheus flag

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/heptiolabs/eventrouter/sinks"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/viper"
 
 	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -55,8 +56,10 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(kubernetesWarningEventCounterVec)
-	prometheus.MustRegister(kubernetesNormalEventCounterVec)
+	if viper.GetBool("enable-prometheus") {
+		prometheus.MustRegister(kubernetesWarningEventCounterVec)
+		prometheus.MustRegister(kubernetesNormalEventCounterVec)
+	}
 }
 
 // EventRouter is responsible for maintaining a stream of kubernetes
@@ -124,6 +127,9 @@ func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 
 // prometheusEvent is called when an event is added or updated
 func prometheusEvent(event *v1.Event) {
+	if !viper.GetBool("enable-prometheus") {
+		return
+	}
 	var counter prometheus.Counter
 	var err error
 

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func loadConfig() kubernetes.Interface {
 	viper.SetDefault("kubeconfig", "")
 	viper.SetDefault("sink", "glog")
 	viper.SetDefault("resync-interval", time.Minute*30)
+	viper.SetDefault("enable-prometheus", true)
 	if err = viper.ReadInConfig(); err != nil {
 		panic(err.Error())
 	}
@@ -114,11 +115,13 @@ func main() {
 	stop := sigHandler()
 
 	// Startup the http listener for Prometheus Metrics endpoint.
-	go func() {
-		glog.Info("Starting prometheus metrics.")
-		http.Handle("/metrics", promhttp.Handler())
-		glog.Warning(http.ListenAndServe(*addr, nil))
-	}()
+	if viper.GetBool("enable-prometheus") {
+		go func() {
+			glog.Info("Starting prometheus metrics.")
+			http.Handle("/metrics", promhttp.Handler())
+			glog.Warning(http.ListenAndServe(*addr, nil))
+		}()
+	}
 
 	// Startup the EventRouter
 	wg.Add(1)


### PR DESCRIPTION
Prometheus metrics seem to be leaking memory. For this reason, it would be nice to be able to disable the metrics. I have added a configuration option to disable prometheus. The option defaults to enabled to keep current functionality.

The graph below shows the eventrouter pod's memory used (in megabytes) over a month of time. Each drop off correlates to a deploy of the service. The most recent deploy was that of the build of this PR with prometheus metrics disabled.

![Screen Shot 2019-09-12 at 3 36 20 PM](https://user-images.githubusercontent.com/28708077/64819556-1b276500-d574-11e9-8f25-98893e8a65f7.png)
