### PR TITLE
The apps/v1beta2 Deployment is deprecated, move to apps/v1

### DIFF
--- a/yaml/eventrouter.yaml
+++ b/yaml/eventrouter.yaml
@@ -51,7 +51,7 @@ metadata:
   name: eventrouter-cm
   namespace: kube-system
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: eventrouter


### PR DESCRIPTION
Per the Kubernetes v1.16.0 release notes, the apps/v1beta2 deployments
endpoint is not served by default and so we should update our example
to use the preferred API endpoint.

Fixes #85

Signed-off-by: John Schnake <jschnake@vmware.com>