### PR TITLE
Fix bug where viper values were read before ready

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -55,13 +55,6 @@ var (
 	})
 )
 
-func init() {
-	if viper.GetBool("enable-prometheus") {
-		prometheus.MustRegister(kubernetesWarningEventCounterVec)
-		prometheus.MustRegister(kubernetesNormalEventCounterVec)
-	}
-}
-
 // EventRouter is responsible for maintaining a stream of kubernetes
 // system Events and pushing them to another channel for storage
 type EventRouter struct {
@@ -81,6 +74,11 @@ type EventRouter struct {
 
 // NewEventRouter will create a new event router using the input params
 func NewEventRouter(kubeClient kubernetes.Interface, eventsInformer coreinformers.EventInformer) *EventRouter {
+	if viper.GetBool("enable-prometheus") {
+		prometheus.MustRegister(kubernetesWarningEventCounterVec)
+		prometheus.MustRegister(kubernetesNormalEventCounterVec)
+	}
+
 	er := &EventRouter{
 		kubeClient: kubeClient,
 		eSink:      sinks.ManufactureSink(),


### PR DESCRIPTION
The init() method is invoked before viper has actually parsed
the values in the flags/configs. Delay this until getting an
EventRouter to have the value available.

Fixes #89

Signed-off-by: John Schnake <jschnake@vmware.com>